### PR TITLE
feat(test): 調整後端測試的語法

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
         working-directory: ./client
         run: npm test
 
-  build-server:
-    name: Build Server
+  build-and-test-server:
+    name: Build and Test Server
     runs-on: ubuntu-latest
     needs: lint
     steps:
@@ -95,3 +95,7 @@ jobs:
       - name: Build server application
         working-directory: ./server
         run: npm run build --if-present
+
+      - name: Run server tests
+        working-directory: ./server
+        run: npm test

--- a/server/src/utils/__test__/password.utils.test.ts
+++ b/server/src/utils/__test__/password.utils.test.ts
@@ -1,0 +1,63 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("bcryptjs", () => ({
+	genSaltSync: jest.fn(),
+	hashSync: jest.fn(),
+}));
+
+import bcrypt from "bcryptjs";
+
+describe("hashPassword 工具函式測試", () => {
+	let hashPassword: (password: string, saltRounds?: number) => string;
+	let mockedBcrypt: jest.MockedObject<typeof bcrypt>;
+	beforeEach(async () => {
+		hashPassword = (await import("../password.utils")).hashPassword;
+		const bcrypt = await import("bcryptjs");
+		mockedBcrypt = jest.mocked(bcrypt);
+	});
+
+	test("應正確呼叫 bcryptjs 的函式並回傳雜湊後的密碼", async () => {
+		const passwordInput = "password123";
+		const saltRoundsInput = 5;
+		const expectedSalt = "test-salt";
+		const expectedHashedPassword = "mockedHashedPasswordValue";
+
+		mockedBcrypt.genSaltSync.mockReturnValue(expectedSalt);
+		mockedBcrypt.hashSync.mockReturnValue(expectedHashedPassword);
+
+		const hashedPassword = hashPassword(passwordInput, saltRoundsInput);
+
+		expect(mockedBcrypt.genSaltSync).toHaveBeenCalledTimes(1);
+		expect(mockedBcrypt.genSaltSync).toHaveBeenCalledWith(saltRoundsInput);
+
+		expect(mockedBcrypt.hashSync).toHaveBeenCalledTimes(1);
+		expect(mockedBcrypt.hashSync).toHaveBeenCalledWith(
+			passwordInput,
+			expectedSalt
+		);
+
+		expect(hashedPassword).toBe(expectedHashedPassword);
+	});
+
+	test("若無傳入 'saltRound' 參數，應正確帶入預設值 '10'", async () => {
+		const passwordInput = "password123";
+		const expectedSalt = "test-salt";
+		const expectedHashedPassword = "mockedHashedPasswordValue";
+
+		mockedBcrypt.genSaltSync.mockReturnValue(expectedSalt);
+		mockedBcrypt.hashSync.mockReturnValue(expectedHashedPassword);
+
+		const hashedPassword = hashPassword(passwordInput);
+
+		expect(mockedBcrypt.genSaltSync).toHaveBeenCalledTimes(1);
+		expect(mockedBcrypt.genSaltSync).toHaveBeenCalledWith(10);
+
+		expect(mockedBcrypt.hashSync).toHaveBeenCalledTimes(1);
+		expect(mockedBcrypt.hashSync).toHaveBeenCalledWith(
+			passwordInput,
+			expectedSalt
+		);
+
+		expect(hashedPassword).toBe(expectedHashedPassword);
+	});
+});

--- a/server/src/utils/password.utils.ts
+++ b/server/src/utils/password.utils.ts
@@ -1,4 +1,4 @@
-import bcrypt from "bcryptjs";
+import * as bcrypt from "bcryptjs";
 
 /**
  * 加密密碼的工具函式

--- a/server/src/utils/sum.ts
+++ b/server/src/utils/sum.ts
@@ -1,3 +1,0 @@
-export default function sum(a: number, b: number) {
-	return a + b;
-}


### PR DESCRIPTION
注意：在後端進行測試時，需以動態導入來導入模組
- 在後端測試模組時，需以 `import()` 語法導入需被測試以及需被 `mock` 的模組
- 需以 `jest.unstable_mockModule` 取代 `jest.mock` 才能在 ESM 模組與 Node.js 環境中 正確地進行 Mocking 的動作
- 在 `ci` 中重新新增後端的測試邏輯